### PR TITLE
Add whitenoise to requirements.txt

### DIFF
--- a/sample/ellar-and-django-orm/requirements.txt
+++ b/sample/ellar-and-django-orm/requirements.txt
@@ -1,3 +1,4 @@
 Django
 ellar-cli
 ellar-django-module
+whitenoise


### PR DESCRIPTION
Trying running `manage.py` in the sample app without having installed whitenoise errors like this:

```python
  File "/home/paolo/path/.venv/lib/python3.10/site-packages/ellar/core/modules/config.py", line 193, in get_module
    raise ImproperConfiguration(
ellar.common.exceptions.api.exceptions_types.ImproperConfiguration: Unable to import "ellar_and_django_orm.root_module:ApplicationModule" registered in "AppFactory"
```

I had to put some breakpoint to understand the reason because the `ModuleNotFoundError` exception was not shown.

```
  File "/home/paolo/path/.venv/lib/python3.10/site-packages/django/utils/module_loading.py", line 15, in cached_import
    module = import_module(module_path)
  File "/home/paolo/.pyenv/versions/3.10.4/lib/python3.10/importlib/__init__.py", line 126, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
  File "<frozen importlib._bootstrap>", line 1050, in _gcd_import
  File "<frozen importlib._bootstrap>", line 1027, in _find_and_load
  File "<frozen importlib._bootstrap>", line 992, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 241, in _call_with_frames_removed
  File "<frozen importlib._bootstrap>", line 1050, in _gcd_import
  File "<frozen importlib._bootstrap>", line 1027, in _find_and_load
  File "<frozen importlib._bootstrap>", line 1004, in _find_and_load_unlocked
ModuleNotFoundError: No module named 'whitenoise'

The above exception was the direct cause of the following exception:
...
```